### PR TITLE
Add `config` command to set default configurations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
     
     - run: |
-        conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich
+        conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich tomlkit
         pip install . --no-deps
     
     - name: Run Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3
 
-RUN conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov rich
+RUN conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov rich tomlkit
 
 COPY . /ezconda
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3
 
-RUN conda install -c conda-forge pip typer PyYaml pytest pytest-cov rich mamba
+RUN conda install -c conda-forge pip typer PyYaml pytest pytest-cov rich mamba tomlkit
   
 COPY . /ezconda
 

--- a/ezconda/config.py
+++ b/ezconda/config.py
@@ -1,7 +1,7 @@
 import typer
 from pathlib import Path
-import json
 from typing import Optional, Dict
+import tomlkit
 
 from .solver import Solver
 
@@ -10,7 +10,7 @@ from .console import console
 
 # get ezconda config file
 app_dir = typer.get_app_dir("ezconda")
-config_file: Path = Path(app_dir) / "config.json"
+config_file: Path = Path(app_dir) / "config.toml"
 
 
 def check_configs(
@@ -26,7 +26,7 @@ def check_configs(
         # check if config file exists
         if config_file.is_file():
             with open(config_file, "r") as f:
-                configs = json.load(f)
+                configs = tomlkit.load(f)
             return configs
 
 
@@ -48,7 +48,7 @@ def make_and_read_config_file(
 
     else:
         with open(config_file, "r") as f:
-            configs = json.load(f)
+            configs = tomlkit.load(f)
 
     return configs
 
@@ -88,7 +88,7 @@ def config(
         configs.update({"solver": solver})
 
     with open(config_file, "w") as f:
-        json.dump(configs, f)
+        tomlkit.dump(configs, f)
 
     if show:
         console.print(f"[bold green]Current Configuration")

--- a/ezconda/config.py
+++ b/ezconda/config.py
@@ -91,5 +91,5 @@ def config(
         json.dump(configs, f)
 
     if show:
-        console.rule(f"[bold green]Current Configuration")
-        console.print_json(data=configs)
+            console.print(f"[bold green]Current Configuration")
+            console.print_json(data=configs)

--- a/ezconda/config.py
+++ b/ezconda/config.py
@@ -33,6 +33,8 @@ def check_configs(
 def make_and_read_config_file(
     app_dir: str = app_dir, config_file: Path = config_file
 ) -> Dict:
+    """Create config file if it doesn't exist and return empty dict of configs.
+    If one exists, read it and return a dict of configs."""
 
     # create app directory if it doesn't exist
     if not Path(app_dir).is_dir():

--- a/ezconda/config.py
+++ b/ezconda/config.py
@@ -1,0 +1,93 @@
+import typer
+from pathlib import Path
+import json
+from typing import Optional, Dict
+
+from .solver import Solver
+
+from .console import console
+
+
+# get ezconda config file
+app_dir = typer.get_app_dir("ezconda")
+config_file: Path = Path(app_dir) / "config.json"
+
+
+def check_configs(
+    app_dir: str = app_dir, config_file: Path = config_file
+) -> Optional[Dict]:
+    """
+    Check app config file for user settings.
+    Retruns a dict of configs if they exist.
+    """
+
+    # check if directory exists
+    if Path(app_dir).is_dir():
+        # check if config file exists
+        if config_file.is_file():
+            with open(config_file, "r") as f:
+                configs = json.load(f)
+            return configs
+
+
+def make_and_read_config_file(
+    app_dir: str = app_dir, config_file: Path = config_file
+) -> Dict:
+
+    # create app directory if it doesn't exist
+    if not Path(app_dir).is_dir():
+        Path(app_dir).mkdir(parents=True)
+
+    # create config file if it doesn't exist
+    # this will happen the first time config is run
+    if not config_file.is_file():
+        config_file.touch()
+        configs = {}
+
+    else:
+        with open(config_file, "r") as f:
+            configs = json.load(f)
+
+    return configs
+
+
+def get_default_solver() -> Solver:
+    """Checks config file for default solver.
+    If config file or solver related config doesn't exist,
+    returns mamba as default solver.
+    """
+    config = check_configs()
+
+    if config:
+        if config.get("solver") is not None:
+            solver = config["solver"]
+        else:
+            solver = Solver.mamba
+    else:
+        solver = Solver.mamba
+    return solver
+
+
+def config(
+    solver: Solver = typer.Option(
+        None,
+        "--solver",
+        help="Set default solver",
+        case_sensitive=False,
+    ),
+    show: bool = typer.Option(False, "--show", help="Show current config"),
+):
+    """
+    Configure default settings for ezconda
+    """
+    configs = make_and_read_config_file()
+
+    if solver:
+        configs.update({"solver": solver})
+
+    with open(config_file, "w") as f:
+        json.dump(configs, f)
+
+    if show:
+        console.rule(f"[bold green]Current Configuration")
+        console.print_json(data=configs)

--- a/ezconda/config.py
+++ b/ezconda/config.py
@@ -91,5 +91,5 @@ def config(
         json.dump(configs, f)
 
     if show:
-            console.print(f"[bold green]Current Configuration")
-            console.print_json(data=configs)
+        console.print(f"[bold green]Current Configuration")
+        console.print_json(data=configs)

--- a/ezconda/create.py
+++ b/ezconda/create.py
@@ -9,6 +9,7 @@ from .console import console
 from ._utils import create_initial_env_specs, write_env_file
 from .solver import Solver
 from .experimental import write_lock_file
+from .config import get_default_solver
 
 
 def create(
@@ -23,9 +24,7 @@ def create(
     channel: Optional[str] = typer.Option(
         None, "--channel", "-c", help="Additional channel to search for packages"
     ),
-    solver: Solver = typer.Option(
-        Solver.mamba, help="Solver to use", case_sensitive=False
-    ),
+    solver: Solver = typer.Option(None, help="Solver to use", case_sensitive=False),
     file: Optional[Path] = typer.Option(
         None, "--file", "-f", help="Name of the environment yml file"
     ),
@@ -62,6 +61,9 @@ def create(
         console.print(f"[bold yellow]Overwrite {file} ...")
 
     env_specs = create_initial_env_specs(name, channel, packages)
+
+    if solver is None:
+        solver = get_default_solver()
 
     with console.status(f"[magenta]Creating new conda environment {name}") as status:
 

--- a/ezconda/install.py
+++ b/ezconda/install.py
@@ -14,6 +14,7 @@ from ._utils import (
     add_new_channel_to_env_specs,
 )
 from .solver import Solver
+from .config import get_default_solver
 from .experimental import write_lock_file
 
 
@@ -32,9 +33,7 @@ def install(
     channel: Optional[str] = typer.Option(
         None, "--channel", "-c", help="Additional channel to search for packages"
     ),
-    solver: Solver = typer.Option(
-        Solver.mamba, help="Solver to use", case_sensitive=False
-    ),
+    solver: Solver = typer.Option(None, help="Solver to use", case_sensitive=False),
     verbose: Optional[bool] = typer.Option(
         False, "--verbose", "-v", help="Display standard output from conda"
     ),
@@ -53,6 +52,9 @@ def install(
         env_specs = read_env_file(file)
         env_specs = add_pkg_to_dependencies(env_specs, pkg_name)
         env_specs = add_new_channel_to_env_specs(env_specs, channel)
+
+        if solver is None:
+            solver = get_default_solver()
 
         status.update(f"[magenta]Resolving & Installing packages using {solver.value}")
 

--- a/ezconda/main.py
+++ b/ezconda/main.py
@@ -1,4 +1,3 @@
-from distutils.command.config import config
 import typer
 
 from . import __version__

--- a/ezconda/main.py
+++ b/ezconda/main.py
@@ -1,3 +1,4 @@
+from distutils.command.config import config
 import typer
 
 from . import __version__
@@ -8,6 +9,7 @@ from .create import create
 from .install import install
 from .remove import remove
 from .recreate import recreate
+from .config import config
 from .experimental.lock import lock
 
 
@@ -20,6 +22,7 @@ app.command()(install)
 app.command()(remove)
 app.command()(recreate)
 app.command()(lock)
+app.command()(config)
 # app.command()(show)
 
 

--- a/ezconda/recreate.py
+++ b/ezconda/recreate.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .console import console
 from .solver import Solver
+from .config import get_default_solver
 
 
 def read_lock_file_and_install(
@@ -87,9 +88,7 @@ def recreate(
         "-n",
         help="Name of the environment to create",
     ),
-    solver: Solver = typer.Option(
-        Solver.mamba, help="Solver to use", case_sensitive=False
-    ),
+    solver: Solver = typer.Option(None, help="Solver to use", case_sensitive=False),
     verbose: Optional[bool] = typer.Option(
         False, "--verbose", "-v", help="Display standard output from conda"
     ),
@@ -101,6 +100,8 @@ def recreate(
         if Path(file).is_file():
             if name is None:  # pragma: no cover
                 name = Path(file).stem
+            if solver is None:
+                solver = get_default_solver()
             read_lock_file_and_install(file, name, verbose, solver)
         else:
             console.print(f"[bold red]{file} is not a valid file")

--- a/ezconda/remove.py
+++ b/ezconda/remove.py
@@ -17,6 +17,7 @@ from ._utils import (
     recheck_dependencies,
 )
 from .solver import Solver
+from .config import get_default_solver
 from .experimental import write_lock_file
 
 
@@ -29,9 +30,7 @@ def remove(
         prompt="Name of the environment to remove from",
         help="Name of the environment to uninstall package from",
     ),
-    solver: Solver = typer.Option(
-        Solver.mamba, help="Solver to use", case_sensitive=False
-    ),
+    solver: Solver = typer.Option(None, help="Solver to use", case_sensitive=False),
     file: Optional[str] = typer.Option(
         None, "--file", "-f", help="'.yml' file to update with removed packages"
     ),
@@ -81,6 +80,9 @@ def remove(
         env_specs = remove_pkg_from_dependencies(env_specs, pkg_name)
 
         status.update("[magenta]Removing packages")
+
+        if solver is None:
+            solver = get_default_solver()
 
         p = subprocess.run(
             [

--- a/poetry.lock
+++ b/poetry.lock
@@ -337,6 +337,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tomlkit"
+version = "0.9.0"
+description = "Style preserving TOML library"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[[package]]
 name = "typer"
 version = "0.4.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -397,7 +405,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "ad8bf65c425186c290b3f60f94f8c975531c1d978ac509a9394480444de08aeb"
+content-hash = "f7e666072d6b8f1f6772726d8920ae359d1fba8196cb952561317d4938b59cef"
 
 [metadata.files]
 atomicwrites = [
@@ -573,6 +581,10 @@ shellingham = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+tomlkit = [
+    {file = "tomlkit-0.9.0-py3-none-any.whl", hash = "sha256:c1b0fc73abd4f1e77c29ea4061ca0f2e11cbfb77342e17df3d3fdd496fc3f899"},
+    {file = "tomlkit-0.9.0.tar.gz", hash = "sha256:5a83672c565f78f5fc8f1e44e5f2726446cc6b765113efd21d03e9331747d9ab"},
 ]
 typer = [
     {file = "typer-0.4.0-py3-none-any.whl", hash = "sha256:d81169725140423d072df464cad1ff25ee154ef381aaf5b8225352ea187ca338"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.6"
 typer = {extras = ["all"], version = "^0.4.0"}
 PyYAML = "^5.4.1"
 rich = "^10.11.0"
+tomlkit = "^0.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def clean_up_env_after_test():
 @pytest.fixture()
 def delete_config_file():
     app_dir = typer.get_app_dir("ezconda")
-    config_file: Path = Path(app_dir) / "config.json"
+    config_file: Path = Path(app_dir) / "config.toml"
     yield
     """Remove config file after each test runs"""
     subprocess.run(["rm", "-rf", config_file])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
+import imp
 import pytest
 import subprocess
 import sys
+import typer
+from pathlib import Path
 
 
 @pytest.fixture()
@@ -16,3 +19,12 @@ def clean_up_env_after_test():
         subprocess.run(["rm", "-rf", "test-win-64.lock"])
     elif sys.platform == "linux":
         subprocess.run(["rm", "-rf", "test-linux-64.lock"])
+
+
+@pytest.fixture()
+def delete_config_file():
+    app_dir = typer.get_app_dir("ezconda")
+    config_file: Path = Path(app_dir) / "config.json"
+    yield
+    """Remove config file after each test runs"""
+    subprocess.run(["rm", "-rf", config_file])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import typer
 import pytest
 from pathlib import Path
@@ -16,7 +15,7 @@ config_file: Path = Path(app_dir) / "config.json"
 
 
 @pytest.mark.usefixtures("delete_config_file")
-def test_make_config_file(delete_config_file):
+def test_make_config_file(delete_config_file) -> None:
     # check that it doesn't exist
     assert not config_file.is_file()
 
@@ -29,13 +28,24 @@ def test_make_config_file(delete_config_file):
     assert configs == {}
 
 
-def test_default_solver_when_none_is_set():
+@pytest.mark.usefixtures("delete_config_file")
+def test_make_and_read_config_file(delete_config_file) -> None:
+    # create config file with the config command
+    result = runner.invoke(app, ["config", "--solver", "conda"])
+
+    # check that we can read the config file after creation
+    configs = make_and_read_config_file(app_dir, config_file)
+    # check what we set was saved in the configs file
+    assert configs["solver"] == "conda"
+
+
+def test_default_solver_when_none_is_set() -> None:
     solver = get_default_solver()
     assert solver == Solver.mamba
 
 
 @pytest.mark.usefixtures("delete_config_file")
-def test_default_solver_after_setting_it(delete_config_file):
+def test_default_solver_after_setting_it(delete_config_file) -> None:
     result = runner.invoke(app, ["config", "--solver", "conda"])
 
     # check if it was successful
@@ -47,3 +57,12 @@ def test_default_solver_after_setting_it(delete_config_file):
     # check that the default solver is set to conda
     solver = get_default_solver()
     assert solver == Solver.conda
+
+
+@pytest.mark.usefixtures("delete_config_file")
+def test_show_configs(delete_config_file) -> None:
+    _ = runner.invoke(app, ["config", "--solver", "conda"])
+
+    result = runner.invoke(app, ["config", "--show"])
+
+    assert 'Current Configuration\n{\n  "solver": "conda"\n}\n' in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,49 @@
+from typing import Dict
+import typer
+import pytest
+from pathlib import Path
+from typer.testing import CliRunner
+
+from ezconda.solver import Solver
+from ezconda.config import make_and_read_config_file, get_default_solver
+from ezconda.main import app
+
+
+runner = CliRunner()
+
+app_dir = typer.get_app_dir("ezconda")
+config_file: Path = Path(app_dir) / "config.json"
+
+
+@pytest.mark.usefixtures("delete_config_file")
+def test_make_config_file(delete_config_file):
+    # check that it doesn't exist
+    assert not config_file.is_file()
+
+    # create config file
+    configs = make_and_read_config_file(app_dir, config_file)
+
+    # check that it exists after creation
+    assert config_file.is_file()
+    # because it didn't exist before, configs dict should be empty
+    assert configs == {}
+
+
+def test_default_solver_when_none_is_set():
+    solver = get_default_solver()
+    assert solver == Solver.mamba
+
+
+@pytest.mark.usefixtures("delete_config_file")
+def test_default_solver_after_setting_it(delete_config_file):
+    result = runner.invoke(app, ["config", "--solver", "conda"])
+
+    # check if it was successful
+    assert result.exit_code == 0
+
+    # check that a config file was created
+    assert config_file.is_file()
+
+    # check that the default solver is set to conda
+    solver = get_default_solver()
+    assert solver == Solver.conda

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ from ezconda.main import app
 runner = CliRunner()
 
 app_dir = typer.get_app_dir("ezconda")
-config_file: Path = Path(app_dir) / "config.json"
+config_file: Path = Path(app_dir) / "config.toml"
 
 
 @pytest.mark.usefixtures("delete_config_file")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -18,7 +18,9 @@ def test_install_w_no_existing_pkgs(clean_up_env_after_test):
 @pytest.mark.usefixtures("clean_up_env_after_test")
 def test_verbose_install_w_conda(clean_up_env_after_test):
     _ = runner.invoke(app, ["create", "-n", "test"])
-    result = runner.invoke(app, ["install", "-n", "test", "python=3.8", "-v", "--solver", "conda"])
+    result = runner.invoke(
+        app, ["install", "-n", "test", "python=3.8", "-v", "--solver", "conda"]
+    )
 
     assert "Collecting package metadata (current_repodata.json):" in result.stdout
 


### PR DESCRIPTION
This PR adds `config` command to ezconda.

You can now set the default solver:
```console
$ ezconda config --solver mamba

# sets mamba as the default solver
```
And, view current configurations:
```console
$ ezconda config --show

# shows the current configurations
```

Closes #12 