### PR TITLE
Add `summary` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     
-    - uses: s-weigand/setup-conda@v1
+    - uses: s-weigand/setup-conda@v1.1.0
     
     - run: |
         conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich tomlkit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,9 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-    
-    - run: |
+    - name: Install Packages and Run Tests
+      shell: bash -l {0}
+      run: |
         conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich tomlkit
         pip install . --no-deps
         pytest --cov=ezconda

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest] #, windows-latest]
     
     steps:
     - uses: actions/checkout@v2.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,6 @@ jobs:
     - run: |
         conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich tomlkit
         pip install . --no-deps
-    
-    - name: Run Tests
-      run: |
         pytest --cov=ezconda
         coverage xml
         codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,11 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2.3.4
-    
-    - uses: s-weigand/setup-conda@v1.1.0
+
+    - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
     
     - run: |
         conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich tomlkit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
     
     - run: |
         conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich tomlkit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     
     steps:
     - uses: actions/checkout@v2.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v2.3.4
 
     - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
+      with:
+        auto-update-conda: true
     
     - run: |
         conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov codecov coverage rich tomlkit

--- a/docs/user_guide/create_new_env.md
+++ b/docs/user_guide/create_new_env.md
@@ -68,23 +68,10 @@ dependencies:
     - python=3.9
 ```
 
-## Providing specifications file name
-
-You may have observed above that the name the environment `new-proj` is also the name of the environment specifcations file `new-proj.yml`.
-
-However, you can use the `-f` or `--file` flag if you would like to use a file name that isn't same as the environment name.
-
-<div class="termy">
-
-```console
-$ ezconda create -n new-proj -f awesome-proj.yml python=3.9
-
-// Saves environment specs to 'awesome-proj.yml'
-
-```
-</div>
-
 !!! Note
+
+    The environment name `new-proj` is also the name of the environment specifcations file `new-proj.yml`.
+
     It is recommended to keep the environment name and specifications file name the same.
 
 

--- a/docs/user_guide/summary.md
+++ b/docs/user_guide/summary.md
@@ -1,0 +1,54 @@
+# Environment Summary
+
+You can get a summary of the changes made to the environment using the `summary` command.
+
+## Latest transaction summary
+
+You can specify the environment you want to get summary of using the `-n` or `--name` option:
+
+<div class="termy">
+
+```console
+$ ezconda summary -n ml-proj
+
+// Prints the latest transaction summary of ml-proj environment
+```
+
+</div>
+
+!!! Note
+    By default, the `summary` command shows the information about the latest transaction.
+
+## For a specific revision
+
+You can also specify the environment revision number for which you want the summary using `--revision`:
+
+<div class="termy">
+
+```console
+$ ezconda summary -n ml-proj --revision 2
+
+// Prints the summary of the 2nd environment transaction
+```
+
+</div>
+
+## Summary for every command
+
+You can get a summary of transactions with every command using the `--summary` option.
+
+<div class="termy">
+
+```console
+$ ezconda install -n sciml numpy --summary
+
+// Prints the summary of the transaction after command completes successfully
+```
+
+</div>
+
+!!! Note
+
+    The `--summary` option is passed to explicitly demonstrate its usage; `--summary` is passed by default for all commands.
+    
+    You can turn it off by passing `--no-summary`.

--- a/ezconda/create.py
+++ b/ezconda/create.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .console import console
 from ._utils import create_initial_env_specs, write_env_file, read_env_file
 from .solver import Solver
+from .summary import get_summary_for_revision
 from .experimental import write_lock_file
 from .config import get_default_solver
 
@@ -26,6 +27,9 @@ def create(
     file: Optional[Path] = typer.Option(
         None, "--file", "-f", help="Name of the environment yml file"
     ),
+    summary: bool = typer.Option(
+        True, "--summary", help="Show summary of changes made"
+    ),
     verbose: Optional[bool] = typer.Option(
         False, "--verbose", "-v", help="Display standard output from conda"
     ),
@@ -42,13 +46,14 @@ def create(
     if file is None:
         if name is None:
             name = typer.prompt("Name of the environment to create")
-        
+
         file = Path(f"{name}.yml")
 
         # check if file (and likely environment) already exists
         if file.is_file():
-            overwrite = typer.confirm(dedent(
-                f"""
+            overwrite = typer.confirm(
+                dedent(
+                    f"""
                 There is an existing {file} file.
 
                 Please note that this likely means you have an existing conda environment with the same name as {name}.
@@ -67,7 +72,9 @@ def create(
         if solver is None:
             solver = get_default_solver()
 
-        with console.status(f"[magenta]Creating new conda environment {name}") as status:
+        with console.status(
+            f"[magenta]Creating new conda environment {name}"
+        ) as status:
 
             if packages:
                 status.update(
@@ -108,7 +115,9 @@ def create(
 
             status.update(f"[magenta]Writing specifications to {file}")
             write_env_file(env_specs, file)
-            console.print(f"[bold green] :floppy_disk: Saved specifications to '{file}'")
+            console.print(
+                f"[bold green] :floppy_disk: Saved specifications to '{file}'"
+            )
 
             if (
                 lock and packages
@@ -116,29 +125,36 @@ def create(
                 status.update(f"[magenta]Writing lock file")
 
                 write_lock_file(name)
-        
+
     elif file.is_file():
-        with console.status(f"[magenta]Creating new conda environment using {file}") as status:
+        with console.status(
+            f"[magenta]Creating new conda environment using {file}"
+        ) as status:
 
             p = subprocess.run(
                 ["conda", "env", "create", "--file", file],
                 capture_output=True,
                 text=True,
             )
-            
+
             if p.returncode != 0:
                 console.print(f"[red]{str(p.stdout + p.stderr)}")
                 raise typer.Exit()
-            
-            # get env name from yml file
-            env_name = read_env_file(file)["name"]
-            console.print(f"[bold green] :rocket: Created '{env_name}' environment")
 
-            if lock:  # only write lock file if packages are mentioned during env creation
+            # get env name from yml file
+            name = read_env_file(file)["name"]
+            console.print(f"[bold green] :rocket: Created '{name}' environment")
+
+            if (
+                lock
+            ):  # only write lock file if packages are mentioned during env creation
                 status.update(f"[magenta]Writing lock file")
-                write_lock_file(env_name)
+                write_lock_file(name)
 
             if verbose:
                 console.print(f"[bold yellow]{str(p.stdout)}")
 
     console.print(f"[bold green] :star: Done!")
+
+    if summary:
+        get_summary_for_revision(name)

--- a/ezconda/files/lockfile.py
+++ b/ezconda/files/lockfile.py
@@ -111,7 +111,7 @@ class LockFile:
 
                     [bold green]ezconda create -n <environment_name> -f <env.yml>[/]
                     """
-                ) # TODO: add creating env from yml file
+                )  # TODO: add creating env from yml file
             )
             raise typer.Exit()
 

--- a/ezconda/install.py
+++ b/ezconda/install.py
@@ -2,8 +2,6 @@ import subprocess
 import typer
 from typing import List, Optional
 from pathlib import Path
-from conda.cli.python_api import Commands
-from conda.cli.python_api import run_command
 
 from .console import console
 from ._utils import (
@@ -15,6 +13,7 @@ from ._utils import (
 )
 from .solver import Solver
 from .config import get_default_solver
+from .summary import get_summary_for_revision
 from .experimental import write_lock_file
 
 
@@ -34,6 +33,9 @@ def install(
         None, "--channel", "-c", help="Additional channel to search for packages"
     ),
     solver: Solver = typer.Option(None, help="Solver to use", case_sensitive=False),
+    summary: bool = typer.Option(
+        True, "--summary", help="Show summary of changes made"
+    ),
     verbose: Optional[bool] = typer.Option(
         False, "--verbose", "-v", help="Display standard output from conda"
     ),
@@ -100,3 +102,6 @@ def install(
             write_lock_file(env_name)
 
         console.print(f"[bold green] :star: Done!")
+
+        if summary:
+            get_summary_for_revision(env_name)

--- a/ezconda/main.py
+++ b/ezconda/main.py
@@ -9,6 +9,7 @@ from .install import install
 from .remove import remove
 from .recreate import recreate
 from .config import config
+from .summary import summary
 from .experimental.lock import lock
 
 
@@ -21,6 +22,7 @@ app.command()(install)
 app.command()(remove)
 app.command()(recreate)
 app.command()(lock)
+app.command()(summary)
 app.command()(config)
 # app.command()(show)
 

--- a/ezconda/summary.py
+++ b/ezconda/summary.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 from textwrap import dedent
+from py import code
 import typer
 
 from rich.tree import Tree
@@ -22,7 +23,7 @@ def summary(
         help="Revision number to summarize; default is latest",
     ),
 ):
-    get_summary_for_revision(name, revision_no=revision)
+    _ = get_summary_for_revision(name, revision_no=revision)
 
 
 def get_summary_for_revision(name: str, revision_no: int = -1):
@@ -46,17 +47,17 @@ def get_summary_for_revision(name: str, revision_no: int = -1):
         console.print(
             f"[red]Revision {revision_no} not found.\nYou have {len(_rev_data)} revisions for {name} environment."
         )
-        raise typer.Exit()
+        raise typer.Exit(code=1)
 
     _installed = _info["install"]
     _upgraded = _info["upgrade"]
     _removed = _info["remove"]
-    _downgrade = _info["downgrade"]
+    _downgraded = _info["downgrade"]
 
     console.print(
         dedent(
             f"""
-            [bold green]{len(_installed)} Installs,[/] [bold purple]{len(_upgraded)} Upgrades[/], [bold yellow]{len(_downgrade)} Downgrades[/], [bold red]{len(_removed)} Removals[/]
+            [bold green]{len(_installed)} Installs,[/] [bold purple]{len(_upgraded)} Upgrades[/], [bold yellow]{len(_downgraded)} Downgrades[/], [bold red]{len(_removed)} Removals[/]
             """
         )
     )
@@ -70,14 +71,16 @@ def get_summary_for_revision(name: str, revision_no: int = -1):
         upgrade_branch = tree.add("[bold purple]Upgrades[/]")
         for u in _upgraded:
             upgrade_branch.add(f"[purple]New: {u['new']}[/]\nOld: {u['old']}")
-    if _downgrade:
+    if _downgraded:
         downgrade_branch = tree.add("[bold yellow]Downgrades")
-        for d in _downgrade:
+        for d in _downgraded:
             downgrade_branch.add(f"[yellow]New: {d['new']}[/]\nOld: {d['old']}")
     if _removed:
         removal_branch = tree.add("[bold red]Removals[/]")
         for r in _removed:
             removal_branch.add(f"[red]{r}[/]")
 
-    if _installed or _upgraded or _downgrade or _removed:
+    if _installed or _upgraded or _downgraded or _removed:
         console.print(tree)
+    
+    return _installed, _upgraded, _downgraded, _removed

--- a/ezconda/summary.py
+++ b/ezconda/summary.py
@@ -1,7 +1,6 @@
 import json
 import subprocess
 from textwrap import dedent
-from py import code
 import typer
 
 from rich.tree import Tree

--- a/ezconda/summary.py
+++ b/ezconda/summary.py
@@ -1,0 +1,83 @@
+import json
+import subprocess
+from textwrap import dedent
+import typer
+
+from rich.tree import Tree
+
+from .console import console
+
+
+def summary(
+    name: str = typer.Option(
+        ...,
+        "--name",
+        "-n",
+        prompt="Name of the environment",
+        help="Name of the environment to summarize",
+    ),
+    revision: int = typer.Option(
+        -1,
+        "--revision",
+        help="Revision number to summarize; default is latest",
+    ),
+):
+    get_summary_for_revision(name, revision_no=revision)
+
+
+def get_summary_for_revision(name: str, revision_no: int = -1):
+    """ "
+    Get summary for the revision number of the environment.
+    By default, it will show the latest revision.
+    """
+
+    p = subprocess.run(
+        ["conda", "list", "--revision", "-n", name, "--json"],
+        capture_output=True,
+        text=True,
+    )
+
+    # summary info
+    _rev_data = json.loads(p.stdout)
+
+    try:
+        _info = _rev_data[revision_no]
+    except IndexError:
+        console.print(
+            f"[red]Revision {revision_no} not found.\nYou have {len(_rev_data)} revisions for {name} environment."
+        )
+        raise typer.Exit()
+
+    _installed = _info["install"]
+    _upgraded = _info["upgrade"]
+    _removed = _info["remove"]
+    _downgrade = _info["downgrade"]
+
+    console.print(
+        dedent(
+            f"""
+            [bold green]{len(_installed)} Installs,[/] [bold purple]{len(_upgraded)} Upgrades[/], [bold yellow]{len(_downgrade)} Downgrades[/], [bold red]{len(_removed)} Removals[/]
+            """
+        )
+    )
+
+    tree = Tree("[bold]Summary[/]")
+    if _installed:
+        install_branch = tree.add("[bold green]Installs[/]")
+        for i in _installed:
+            install_branch.add(f"[green]{i}[/]")
+    if _upgraded:
+        upgrade_branch = tree.add("[bold purple]Upgrades[/]")
+        for u in _upgraded:
+            upgrade_branch.add(f"[purple]New: {u['new']}[/]\nOld: {u['old']}")
+    if _downgrade:
+        downgrade_branch = tree.add("[bold yellow]Downgrades")
+        for d in _downgrade:
+            downgrade_branch.add(f"[yellow]New: {d['new']}[/]\nOld: {d['old']}")
+    if _removed:
+        removal_branch = tree.add("[bold red]Removals[/]")
+        for r in _removed:
+            removal_branch.add(f"[red]{r}[/]")
+
+    if _installed or _upgraded or _downgrade or _removed:
+        console.print(tree)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Reproducible environment : "user_guide/recreate_env.md"
     - Lock file for any environment : "user_guide/lock_existing_env.md"
     - Use different solver: "user_guide/changing_solvers.md"
+    - Environment summary: "user_guide/summary.md"
     - Configurations : "user_guide/configuration.md"
     - Autocompletions : "user_guide/autocomplete.md"
   - Design Decisions : 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 import json
 import yaml
@@ -68,6 +69,9 @@ def test_create_env_from_yml_file(clean_up_env_after_test):
         text=True,
     )
     env_dict = json.loads(p.stdout)
-    envs = [env.split("/")[-1] for env in env_dict["envs"]]
+    if sys.platform == "win32":
+        envs = [env.split("\\")[-1] for env in env_dict["envs"]]
+    else:
+        envs = [env.split("/")[-1] for env in env_dict["envs"]]
 
     assert "test" in envs

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,3 +1,5 @@
+import subprocess
+import json
 import pytest
 from typer.testing import CliRunner
 from ezconda.main import app
@@ -6,13 +8,29 @@ from ezconda.main import app
 runner = CliRunner()
 
 
+def check_if_pkg_is_installed(env_name, pkg_name, channel=None):
+    pkg_specs = subprocess.run(
+        ["conda", "list", "-n", env_name, "--json"], capture_output=True
+    )
+    pkg_specs = json.loads(pkg_specs.stdout)
+
+    list_of_pkgs = [pkg["name"] for pkg in pkg_specs]
+    assert pkg_name in list_of_pkgs
+
+    if channel:
+        for pkg in pkg_specs:
+            if pkg["name"] == pkg_name:
+                assert pkg["channel"] == channel
+
+
 @pytest.mark.usefixtures("clean_up_env_after_test")
 def test_install_w_no_existing_pkgs(clean_up_env_after_test):
     _ = runner.invoke(app, ["create", "-n", "test"])
     result = runner.invoke(app, ["install", "-n", "test", "python=3.8"])
 
-    assert "Installed packages" in result.stdout
-    assert "Updated specifications to 'test.yml'" in result.stdout
+    assert result.exit_code == 0
+
+    check_if_pkg_is_installed("test", "python")
 
 
 @pytest.mark.usefixtures("clean_up_env_after_test")
@@ -24,6 +42,10 @@ def test_verbose_install_w_conda(clean_up_env_after_test):
 
     assert "Collecting package metadata (current_repodata.json):" in result.stdout
 
+    assert result.exit_code == 0
+
+    check_if_pkg_is_installed("test", "python")
+
 
 @pytest.mark.usefixtures("clean_up_env_after_test")
 def test_install_w_channel_and_no_existing_pkgs(clean_up_env_after_test):
@@ -32,8 +54,9 @@ def test_install_w_channel_and_no_existing_pkgs(clean_up_env_after_test):
         app, ["install", "-n", "test", "-c", "conda-forge", "python=3.8"]
     )
 
-    assert "Installed packages" in result.stdout
-    assert "Updated specifications to 'test.yml'" in result.stdout
+    assert result.exit_code == 0
+
+    check_if_pkg_is_installed("test", "python", channel="conda-forge")
 
 
 @pytest.mark.usefixtures("clean_up_env_after_test")
@@ -43,8 +66,10 @@ def test_install_with_existing_pkgs(clean_up_env_after_test):
     )
     result = runner.invoke(app, ["install", "-n", "test", "-c", "conda-forge", "numpy"])
 
-    assert "Installed packages" in result.stdout
-    assert "Updated specifications to 'test.yml'" in result.stdout
+    assert result.exit_code == 0
+
+    # check if numpy is installed from conda-forge channel
+    check_if_pkg_is_installed("test", "numpy", "conda-forge")
 
 
 @pytest.mark.usefixtures("clean_up_env_after_test")

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -29,7 +29,7 @@ def test_lock_for_existing_conda_envs():
     files = os.listdir()
 
     assert f"lock-test-{sys.platform}-{platform.machine()}.lock" in files
-    
+
     subprocess.run(
         [
             "conda",

--- a/tests/test_recreate.py
+++ b/tests/test_recreate.py
@@ -65,11 +65,11 @@ def test_recreate_w_env_name(clean_up_env_after_test):
     # check if env is created
     envs_installed = json.load(os.popen("conda env list --json"))["envs"]
     if sys.platform == "darwin":
-        assert f"/usr/local/miniconda/envs/{env_name}" in envs_installed
+        assert f"/usr/local/miniconda/envs/test/envs/{env_name}" in envs_installed
     elif sys.platform == "win32":
-        assert f"C:\\Miniconda\\envs\\{env_name}" in envs_installed
+        assert f"C:\\Miniconda\\envs\\test\\envs\\{env_name}" in envs_installed
     else:
-        assert f"/usr/share/miniconda/envs/{env_name}" in envs_installed
+        assert f"/usr/share/miniconda/envs/test/envs/{env_name}" in envs_installed
 
     # check if typer is installed in the env
     pkgs = json.load(os.popen(f"conda list -n {env_name} --json"))

--- a/tests/test_recreate.py
+++ b/tests/test_recreate.py
@@ -32,7 +32,7 @@ def test_recreate_wo_env_name(clean_up_env_after_test):
     # check if env is created
     env_name = "test"  # env name is taken from the lock file
     envs_installed = json.load(os.popen("conda env list --json"))["envs"]
-    
+
     if sys.platform == "darwin":
         assert f"/usr/local/miniconda/envs/{env_name}" in envs_installed
     elif sys.platform == "win32":

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -8,12 +8,14 @@ from ezconda.summary import get_summary_for_revision
 
 runner = CliRunner()
 
+
 @pytest.mark.usefixtures("clean_up_env_after_test")
 def test_index_error(clean_up_env_after_test):
     _ = runner.invoke(app, ["create", "-n", "test", "python=3.8"])
     # test a revision number that does not exist
     result = runner.invoke(app, ["summary", "-n", "test", "--revision", "20"])
     assert result.exit_code == 1
+
 
 @pytest.mark.usefixtures("clean_up_env_after_test")
 def test_installs_upgrade_downgrade_removal_summary(clean_up_env_after_test):
@@ -22,7 +24,9 @@ def test_installs_upgrade_downgrade_removal_summary(clean_up_env_after_test):
     # now install from conda-forge channel
     _ = runner.invoke(app, ["install", "-n", "test", "-c", "conda-forge", "numpy"])
     # test if summary has install, upgrade, downgrade
-    install, upgrade, downgrade, removal = get_summary_for_revision("test", revision_no=-1)
+    install, upgrade, downgrade, removal = get_summary_for_revision(
+        "test", revision_no=-1
+    )
     # check if returns are empty
     assert install
     assert upgrade
@@ -30,5 +34,7 @@ def test_installs_upgrade_downgrade_removal_summary(clean_up_env_after_test):
     # now remove numpy
     _ = runner.invoke(app, ["remove", "-n", "test", "numpy"])
     # test if remove is not empty
-    install, upgrade, downgrade, removal = get_summary_for_revision("test", revision_no=-1)
+    install, upgrade, downgrade, removal = get_summary_for_revision(
+        "test", revision_no=-1
+    )
     assert removal

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,34 @@
+from unittest import runner
+import pytest
+import subprocess
+from typer.testing import CliRunner
+from ezconda.main import app
+from ezconda.summary import get_summary_for_revision
+
+
+runner = CliRunner()
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_index_error(clean_up_env_after_test):
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.8"])
+    # test a revision number that does not exist
+    result = runner.invoke(app, ["summary", "-n", "test", "--revision", "20"])
+    assert result.exit_code == 1
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_installs_upgrade_downgrade_removal_summary(clean_up_env_after_test):
+    # install packages from defaults channel
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.8"])
+    # now install from conda-forge channel
+    _ = runner.invoke(app, ["install", "-n", "test", "-c", "conda-forge", "numpy"])
+    # test if summary has install, upgrade, downgrade
+    install, upgrade, downgrade, removal = get_summary_for_revision("test", revision_no=-1)
+    # check if returns are empty
+    assert install
+    assert upgrade
+    assert downgrade
+    # now remove numpy
+    _ = runner.invoke(app, ["remove", "-n", "test", "numpy"])
+    # test if remove is not empty
+    install, upgrade, downgrade, removal = get_summary_for_revision("test", revision_no=-1)
+    assert removal


### PR DESCRIPTION
This PR adds `summary` command that allows the user to print the summary of changes made to the environment in a specific environment revision. 

```console
ezconda summary --name env
```

This PR also adds `--summary` option to all relevant commands (`create`, `install`, `remove`). The option (by default True) summarizes the changes made to the environment at the end of the command execution.

This PR also changed conda GitHub action from `s-weigand/setup-conda@v1` to `conda-incubator/setup-miniconda@v2`
