### PR TITLE
Add `sync` command to sync out-of-sync local environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3
 
-RUN conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov rich tomlkit
+RUN conda install -c conda-forge mamba pip typer PyYaml pytest pytest-cov rich tomlkit importlib_metadata
 
 COPY . /ezconda
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3
 
-RUN conda install -c conda-forge pip typer PyYaml pytest pytest-cov rich mamba tomlkit
+RUN conda install -c conda-forge pip typer PyYaml pytest pytest-cov rich mamba tomlkit nano
   
 COPY . /ezconda
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3
 
-RUN conda install -c conda-forge pip typer PyYaml pytest pytest-cov rich mamba tomlkit nano
+RUN conda install -c conda-forge pip typer PyYaml pytest pytest-cov rich mamba tomlkit importlib_metadata nano
   
 COPY . /ezconda
 

--- a/docs/user_guide/sync_env.md
+++ b/docs/user_guide/sync_env.md
@@ -1,8 +1,10 @@
-# Syncing Local Environment with Specifications file
+# Sync Local Environment
 
-Use the **`sync`** command to sync local environment with any changes made to the environment specifications file (`.yml` file).
+Use the **`sync`** command to sync local environment with any changes made to the environment specifications file (`.yml` file) or lock file (`.lock` file).
 
-## Example use case for `sync`
+## Example
+
+### Change made to specifications file
 
 ``` mermaid
 sequenceDiagram
@@ -23,16 +25,36 @@ sequenceDiagram
 !!! Tip
     **`sync`** command is useful when **any change** to the specifications file is **made manually or by a collaborator**.
 
+### Change made to lock file
+
+``` mermaid
+sequenceDiagram
+    actor Alice (Mac)
+    participant Repository
+    actor Bob (Mac)
+    Note right of Alice (Mac): Create env, spec & lock file using EZconda
+    Alice (Mac)->>Repository: Push env, spec & lock file
+    Repository->>Bob (Mac): Pull changes
+    Note right of Repository: Add new dependency to project
+    Note right of Repository: Spec file & Lock file updated to reflect the new addition
+    Bob (Mac)->>Repository: Push changes
+    Repository->>Alice (Mac): Pull updated lock file
+    Note right of Alice (Mac): Local environment <-Out of Sync-> New lock file
+    Note right of Alice (Mac): Use `ezconda sync` to sync
+```
+
 ## Sync an environment
 
 Let's say the environment you want to sync is named `ml-proj`.
 
-To sync it with the specifications file, use `sync` command with `--name` or `-n` option:
+To sync it with the specifications file, use `sync` command with `--name`/`-n` option for environment name and `--with` option to explicitly specify `specfile` or `lockfile`:
+
+### To sync with specifications file
 
 <div class="termy">
 
 ```console
-$ ezconda sync -n ml-proj
+$ ezconda sync -n ml-proj --with specfile
 
 // Syncs 'ml-proj' environment with 'ml-proj.yml' file
 ```
@@ -44,15 +66,27 @@ $ ezconda sync -n ml-proj
 
     `ml-proj` environment <--> `ml-proj.yml` specifications file
 
+### To sync with lock file
 
-## Using specifications file
+<div class="termy">
+
+```console
+$ ezconda sync -n ml-proj --with lockfile
+
+// Syncs 'ml-proj' environment with corresponding lock file
+```
+
+</div>
+
+
+## Explicitly specify filename
 
 If your specifications file name is not the same as the environment name, you can pass the file name using `--file` or `-f` option.
 
 <div class="termy">
 
 ```console
-$ ezconda sync -n ml-proj --file env.yml
+$ ezconda sync -n ml-proj --file env.yml --with specfile
 
 // Syncs 'ml-proj' environment with 'env.yml' file
 ```
@@ -69,9 +103,9 @@ By default, if not set using [`config`](configuration.md#set-default-solver), `m
 <div class="termy">
 
 ```console
-$ ezconda sync -n ml-proj --file env.yml --solver conda
+$ ezconda sync -n ml-proj --with specfile --solver conda
 
-// Syncs 'ml-proj' environment with 'env.yml' file using 'conda' solver
+// Syncs 'ml-proj' environment with 'ml-proj.yml' file using 'conda' solver
 ```
 
 </div>

--- a/docs/user_guide/sync_env_with_specfile.md
+++ b/docs/user_guide/sync_env_with_specfile.md
@@ -1,0 +1,77 @@
+# Syncing Local Environment with Specifications file
+
+Use the **`sync`** command to sync local environment with any changes made to the environment specifications file (`.yml` file).
+
+## Example use case for `sync`
+
+``` mermaid
+sequenceDiagram
+    actor Alice (Mac)
+    participant Repository
+    actor Bob (Windows)
+    Note right of Alice (Mac): Create env, spec & lock file using EZconda
+    Alice (Mac)->>Repository: Push env, spec & lock file
+    Repository->>Bob (Windows): Pull changes
+    Note right of Repository: Add new dependency to project
+    Note right of Repository: Spec file changed
+    Bob (Windows)->>Repository: Push changes made to spec file
+    Repository->>Alice (Mac): Pull updated spec file
+    Note right of Alice (Mac): Local environment <-Out of Sync-> New spec file
+    Note right of Alice (Mac): Use `ezconda sync` to sync
+```
+
+!!! Tip
+    **`sync`** command is useful when **any change** to the specifications file is **made manually or by a collaborator**.
+
+## Sync an environment
+
+Let's say the environment you want to sync is named `ml-proj`.
+
+To sync it with the specifications file, use `sync` command with `--name` or `-n` option:
+
+<div class="termy">
+
+```console
+$ ezconda sync -n ml-proj
+
+// Syncs 'ml-proj' environment with 'ml-proj.yml' file
+```
+
+</div>
+
+!!! Note
+    If not specified, the environment specifications file is assumed to have the same filename as the environment name.
+
+    `ml-proj` environment <--> `ml-proj.yml` specifications file
+
+
+## Using specifications file
+
+If your specifications file name is not the same as the environment name, you can pass the file name using `--file` or `-f` option.
+
+<div class="termy">
+
+```console
+$ ezconda sync -n ml-proj --file env.yml
+
+// Syncs 'ml-proj' environment with 'env.yml' file
+```
+
+</div>
+
+
+## Using different solver
+
+You can change the solver using `--solver` flag. 
+
+By default, if not set using [`config`](configuration.md#set-default-solver), `mamba` will be used.
+
+<div class="termy">
+
+```console
+$ ezconda sync -n ml-proj --file env.yml --solver conda
+
+// Syncs 'ml-proj' environment with 'env.yml' file using 'conda' solver
+```
+
+</div>

--- a/ezconda/_utils.py
+++ b/ezconda/_utils.py
@@ -41,7 +41,7 @@ def get_validate_file_name(env_name: str, file: Optional[str] = None) -> Optiona
                 dedent(
                     f"""
             [yellow]If your environment name and specifications file name are not the same,
-            please provide the specifications file name to update using the '-f' or '--file' flag.
+            please provide the specifications file name using the '-f' or '--file' flag.
             """
                 )
             )

--- a/ezconda/main.py
+++ b/ezconda/main.py
@@ -10,6 +10,7 @@ from .remove import remove
 from .recreate import recreate
 from .config import config
 from .summary import summary
+from .sync import sync
 from .experimental.lock import lock
 
 
@@ -23,6 +24,7 @@ app.command()(remove)
 app.command()(recreate)
 app.command()(lock)
 app.command()(summary)
+app.command()(sync)
 app.command()(config)
 # app.command()(show)
 

--- a/ezconda/sync.py
+++ b/ezconda/sync.py
@@ -73,7 +73,7 @@ def sync(
             console.print(f"[yellow]{str(p.stdout)}")
 
         console.print(
-            "[bold green] :arrows_counterclockwise: Environment & specifications file are now in sync!"
+            f"[bold green] :arrows_counterclockwise: '{env_name}' & '{file}' are now in sync!"
         )
 
         if lock:

--- a/ezconda/sync.py
+++ b/ezconda/sync.py
@@ -1,6 +1,10 @@
 import subprocess
 import typer
+import sys
+import platform
 from typing import Optional
+from pathlib import Path
+from enum import Enum
 
 from .console import console
 from ._utils import get_validate_file_name
@@ -8,6 +12,12 @@ from .solver import Solver
 from .config import get_default_solver
 from .summary import get_summary_for_revision
 from .experimental import write_lock_file
+from .recreate import read_lock_file_and_install
+
+
+class SyncFile(str, Enum):
+    specfile = "specfile"
+    lockfile = "lockfile"
 
 
 def sync(
@@ -18,7 +28,13 @@ def sync(
         prompt="Name of the local environment to sync",
         help="Name of the local environment to sync",
     ),
-    file: Optional[str] = typer.Option(
+    sync_with: SyncFile = typer.Option(
+        ...,
+        "--with",
+        prompt=True,
+        help="Sync environment with either lock file or specifications file",
+    ),
+    file: Optional[Path] = typer.Option(
         None,
         "--file",
         "-f",
@@ -34,53 +50,67 @@ def sync(
     lock: Optional[bool] = typer.Option(True, help="Write lockfile"),
 ):
     """
-    Sync local environment with conda-environment 'yml' file.
+    Sync local environment with changes made to environment specifications file ('yml') or lockfile.
 
-    Changes made to the environment yml file will be reflected in the local environment.
+    Syncing local environment with specifications file will update existing lockfile.
     """
 
-    with console.status(f"[magenta]Validating environment and file") as status:
+    if solver is None:
+        solver = get_default_solver()
 
-        file = get_validate_file_name(env_name, file)
-
-        if solver is None:
-            solver = get_default_solver()
-
-        status.update(
-            f"[magenta]Syncing local environment '{env_name}' with file '{file}'"
-        )
-
-        p = subprocess.run(
-            [
-                f"{solver.value}",
-                "env",
-                "update",
-                "-n",
-                env_name,
-                "--file",
-                file,
-                "--prune",
-            ],
-            capture_output=True,
-            text=True,
-        )
-
-        if p.returncode != 0:
-            console.print(f"[red]{str(p.stdout + p.stderr)}")
-            raise typer.Exit()
-
-        if verbose:
-            console.print(f"[yellow]{str(p.stdout)}")
+    if sync_with == SyncFile.lockfile:
+        
+        if file is None:
+            file = Path(f"{env_name}-{sys.platform}-{platform.machine()}.lock")
+        
+        read_lock_file_and_install(file, solver, verbose, env_name)
 
         console.print(
             f"[bold green] :arrows_counterclockwise: '{env_name}' & '{file}' are now in sync!"
         )
 
-        if lock:
-            status.update(f"[magenta]Writing lock file")
-            write_lock_file(env_name)
-
         console.print(f"[bold green] :star: Done!")
 
-        if summary:
-            get_summary_for_revision(env_name)
+    else:
+        with console.status(f"[magenta]Validating environment and file") as status:
+
+            file = get_validate_file_name(env_name, file)
+
+            status.update(
+                f"[magenta]Syncing local environment '{env_name}' with file '{file}'"
+            )
+
+            p = subprocess.run(
+                [
+                    f"{solver.value}",
+                    "env",
+                    "update",
+                    "-n",
+                    env_name,
+                    "--file",
+                    file,
+                    "--prune",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            if p.returncode != 0:
+                console.print(f"[red]{str(p.stdout + p.stderr)}")
+                raise typer.Exit()
+
+            if verbose:
+                console.print(f"[yellow]{str(p.stdout)}")
+
+            console.print(
+                f"[bold green] :arrows_counterclockwise: '{env_name}' & '{file}' are now in sync!"
+            )
+
+            if lock:
+                status.update(f"[magenta]Writing lock file")
+                write_lock_file(env_name)
+
+            console.print(f"[bold green] :star: Done!")
+
+            if summary:
+                get_summary_for_revision(env_name)

--- a/ezconda/sync.py
+++ b/ezconda/sync.py
@@ -1,0 +1,86 @@
+import subprocess
+import typer
+from typing import Optional
+
+from .console import console
+from ._utils import get_validate_file_name
+from .solver import Solver
+from .config import get_default_solver
+from .summary import get_summary_for_revision
+from .experimental import write_lock_file
+
+
+def sync(
+    env_name: str = typer.Option(
+        ...,
+        "--name",
+        "-n",
+        prompt="Name of the local environment to sync",
+        help="Name of the local environment to sync",
+    ),
+    file: Optional[str] = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Environment '.yml' file to use for syncing local environment",
+    ),
+    solver: Solver = typer.Option(None, help="Solver to use", case_sensitive=False),
+    summary: bool = typer.Option(
+        True, "--summary", help="Show summary of changes made"
+    ),
+    verbose: Optional[bool] = typer.Option(
+        False, "--verbose", "-v", help="Display standard output from conda"
+    ),
+    lock: Optional[bool] = typer.Option(True, help="Write lockfile"),
+):
+    """
+    Sync local environment with conda-environment 'yml' file.
+
+    Changes made to the environment yml file will be reflected in the local environment.
+    """
+
+    with console.status(f"[magenta]Validating environment and file") as status:
+
+        file = get_validate_file_name(env_name, file)
+
+        if solver is None:
+            solver = get_default_solver()
+
+        status.update(
+            f"[magenta]Syncing local environment '{env_name}' with file '{file}'"
+        )
+
+        p = subprocess.run(
+            [
+                f"{solver.value}",
+                "env",
+                "update",
+                "-n",
+                env_name,
+                "--file",
+                file,
+                "--prune",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        if p.returncode != 0:
+            console.print(f"[red]{str(p.stdout + p.stderr)}")
+            raise typer.Exit()
+
+        if verbose:
+            console.print(f"[yellow]{str(p.stdout)}")
+
+        console.print(
+            "[bold green] :arrows_counterclockwise: Environment & specifications file are now in sync!"
+        )
+
+        if lock:
+            status.update(f"[magenta]Writing lock file")
+            write_lock_file(env_name)
+
+        console.print(f"[bold green] :star: Done!")
+
+        if summary:
+            get_summary_for_revision(env_name)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,7 @@ nav:
     - Install packages : "user_guide/install_packages.md"
     - Remove packages : "user_guide/remove_packages.md"
     - Reproducible environment : "user_guide/recreate_env.md"
-    - Sync environment with specifications file : "user_guide/sync_env_with_specfile.md"
+    - Sync local environment : "user_guide/sync_env.md"
     - Lock file for any environment : "user_guide/lock_existing_env.md"
     - Use different solver: "user_guide/changing_solvers.md"
     - Environment summary: "user_guide/summary.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
     - Install packages : "user_guide/install_packages.md"
     - Remove packages : "user_guide/remove_packages.md"
     - Reproducible environment : "user_guide/recreate_env.md"
+    - Sync environment with specifications file : "user_guide/sync_env_with_specfile.md"
     - Lock file for any environment : "user_guide/lock_existing_env.md"
     - Use different solver: "user_guide/changing_solvers.md"
     - Environment summary: "user_guide/summary.md"
@@ -68,7 +69,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_div_format
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.keys

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -41,7 +41,7 @@ def test_env_sync_w_lockfile():
     # copy lockfile and rename to test2
     shutil.copy(
         f"test-{sys.platform}-{platform.machine()}.lock",
-        f"test2-{sys.platform}-{platform.machine()}.lock"
+        f"test2-{sys.platform}-{platform.machine()}.lock",
     )
 
     # sync the environment test2 with new test2 lockfile

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -19,7 +19,27 @@ def test_env_sync_w_spec_file():
     write_env_file(env_specs, "test.yml")
 
     # sync the environment
-    _ = runner.invoke(app, ["sync", "-n", "test"])
+    result = runner.invoke(app, ["sync", "-n", "test"])
+
+    assert result.exit_code == 0
 
     # check if numpy is in the environment
+    check_if_pkg_is_installed("test", "numpy")
+
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_verbose_install_w_conda(clean_up_env_after_test):
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.9"])
+
+    # add package to the spec file
+    env_specs = read_env_file("test.yml")
+    env_specs = add_pkg_to_dependencies(env_specs, ["numpy"])
+    write_env_file(env_specs, "test.yml")
+
+    result = runner.invoke(
+        app, ["sync", "-n", "test", "-v", "--solver", "conda"]
+    )
+
+    assert result.exit_code == 0
+
     check_if_pkg_is_installed("test", "numpy")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,4 +1,7 @@
 import pytest
+import shutil
+import sys
+import platform
 from typer.testing import CliRunner
 from ezconda.main import app
 from ezconda._utils import read_env_file, add_pkg_to_dependencies, write_env_file
@@ -9,7 +12,7 @@ runner = CliRunner()
 
 
 @pytest.mark.usefixtures("clean_up_env_after_test")
-def test_env_sync_w_spec_file():
+def test_env_sync_w_specfile():
     # create a new environment
     _ = runner.invoke(app, ["create", "-n", "test", "python=3.9"])
 
@@ -19,12 +22,35 @@ def test_env_sync_w_spec_file():
     write_env_file(env_specs, "test.yml")
 
     # sync the environment
-    result = runner.invoke(app, ["sync", "-n", "test"])
+    result = runner.invoke(app, ["sync", "-n", "test", "--with", "specfile"])
 
     assert result.exit_code == 0
 
     # check if numpy is in the environment
     check_if_pkg_is_installed("test", "numpy")
+
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_env_sync_w_lockfile():
+    # create a new environment with packages
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.9", "numpy"])
+
+    # create a new environment with no packages
+    _ = runner.invoke(app, ["create", "-n", "test2"])
+
+    # copy lockfile and rename to test2
+    shutil.copy(
+        f"test-{sys.platform}-{platform.machine()}.lock",
+        f"test2-{sys.platform}-{platform.machine()}.lock"
+    )
+
+    # sync the environment test2 with new test2 lockfile
+    result = runner.invoke(app, ["sync", "-n", "test2", "--with", "lockfile"])
+
+    assert result.exit_code == 0
+
+    # check if numpy is in the test2 environment that was intially empty
+    check_if_pkg_is_installed("test2", "numpy")
 
 
 @pytest.mark.usefixtures("clean_up_env_after_test")
@@ -37,7 +63,7 @@ def test_verbose_install_w_conda(clean_up_env_after_test):
     write_env_file(env_specs, "test.yml")
 
     result = runner.invoke(
-        app, ["sync", "-n", "test", "-v", "--solver", "conda"]
+        app, ["sync", "-n", "test", "--with", "specfile", "-v", "--solver", "conda"]
     )
 
     assert result.exit_code == 0

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,25 @@
+import pytest
+from typer.testing import CliRunner
+from ezconda.main import app
+from ezconda._utils import read_env_file, add_pkg_to_dependencies, write_env_file
+from .test_install import check_if_pkg_is_installed
+
+
+runner = CliRunner()
+
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_env_sync_w_spec_file():
+    # create a new environment
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.9"])
+
+    # add package to the spec file
+    env_specs = read_env_file("test.yml")
+    env_specs = add_pkg_to_dependencies(env_specs, ["numpy"])
+    write_env_file(env_specs, "test.yml")
+
+    # sync the environment
+    _ = runner.invoke(app, ["sync", "-n", "test"])
+
+    # check if numpy is in the environment
+    check_if_pkg_is_installed("test", "numpy")


### PR DESCRIPTION
# Example use cases:

## Sync to new specfile

```console
$ ezconda sync --name mlproj --with specfile
```

``` mermaid
sequenceDiagram
    actor Alice (Mac)
    participant Repository
    actor Bob (Windows)
    Note right of Alice (Mac): Create env, spec & lock file using EZconda
    Alice (Mac)->>Repository: Push env, spec & lock file
    Repository->>Bob (Windows): Pull changes
    Note right of Repository: Add new dependency to project
    Note right of Repository: Spec file changed
    Bob (Windows)->>Repository: Push changes made to spec file
    Repository->>Alice (Mac): Pull updated spec file
    Note right of Alice (Mac): Local environment <-Out of Sync-> New spec file
    Note right of Alice (Mac): Use `ezconda sync` to sync
```


## Sync to new lockfile

```console
$ ezconda sync --name mlproj --with lockfile
```
``` mermaid
sequenceDiagram
    actor Alice (Mac)
    participant Repository
    actor Bob (Mac)
    Note right of Alice (Mac): Create env, spec & lock file using EZconda
    Alice (Mac)->>Repository: Push env, spec & lock file
    Repository->>Bob (Mac): Pull changes
    Note right of Repository: Add new dependency to project
    Note right of Repository: Spec file & Lock file updated to reflect the new addition
    Bob (Mac)->>Repository: Push changes
    Repository->>Alice (Mac): Pull updated lock file
    Note right of Alice (Mac): Local environment <-Out of Sync-> New lock file
    Note right of Alice (Mac): Use `ezconda sync` to sync
```

Closes #27 