### PR TITLE
Add `update` command

### DIFF
--- a/docs/user_guide/update_environment.md
+++ b/docs/user_guide/update_environment.md
@@ -1,0 +1,29 @@
+# Update Complete Environment
+
+To update an existing `conda` environment (created using **EZconda**), you can use the `update` command.
+
+## Update environment
+
+<div class="termy">
+
+```console
+$ ezconda update -n sciml
+
+// Update `sciml` environment according to `sciml.yml`
+```
+</div>
+
+
+## Specify environment file
+
+<div class="termy">
+
+```console
+$ ezconda update -n sciml --file env.yml
+
+// Update `sciml` environment according to `env.yml`
+```
+</div>
+
+!!! Note
+    If no environment specifications file is passed using `--file` option, EZconda will search and use the specifications file named after the environment.

--- a/ezconda/main.py
+++ b/ezconda/main.py
@@ -11,6 +11,7 @@ from .recreate import recreate
 from .config import config
 from .summary import summary
 from .sync import sync
+from .update import update
 from .experimental.lock import lock
 
 
@@ -25,6 +26,7 @@ app.command()(recreate)
 app.command()(lock)
 app.command()(summary)
 app.command()(sync)
+app.command()(update)
 app.command()(config)
 # app.command()(show)
 

--- a/ezconda/update.py
+++ b/ezconda/update.py
@@ -1,0 +1,84 @@
+import subprocess
+import typer
+from typing import Optional
+from pathlib import Path
+
+from .console import console
+from ._utils import get_validate_file_name
+from .solver import Solver
+from .config import get_default_solver
+from .summary import get_summary_for_revision
+from .experimental import write_lock_file
+
+
+def update(
+    env_name: str = typer.Option(
+        ...,
+        "--name",
+        "-n",
+        prompt="Name of the environment to update",
+        help="Name of the environment to update",
+    ),    
+    file: Optional[Path] = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Environment '.yml' file to use for updating environment",
+    ),
+    solver: Solver = typer.Option(None, help="Solver to use", case_sensitive=False),
+    summary: bool = typer.Option(
+        True, "--summary", help="Show summary of changes made"
+    ),
+    verbose: Optional[bool] = typer.Option(
+        False, "--verbose", "-v", help="Display standard output from conda"
+    ),
+    lock: Optional[bool] = typer.Option(True, help="Write lockfile"),
+):
+    """
+    Update environment according to specifications file.
+    """
+    if solver is None:
+        solver = get_default_solver()
+    
+    with console.status(f"[magenta]Validating environment and file") as status:
+
+        file = get_validate_file_name(env_name, file)
+
+        status.update(
+            f"[magenta]Updating environment '{env_name}' with file '{file}'"
+        )
+
+        p = subprocess.run(
+            [
+                f"{solver.value}",
+                "env",
+                "update",
+                "-n",
+                env_name,
+                "--file",
+                file,
+                "--prune",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        if p.returncode != 0:
+            console.print(f"[red]{str(p.stdout + p.stderr)}")
+            raise typer.Exit()
+
+        if verbose:
+            console.print(f"[yellow]{str(p.stdout)}")
+
+        console.print(
+            f"[bold green] :white_heavy_check_mark: '{env_name}' upadated!"
+        )
+
+        if lock:
+            status.update(f"[magenta]Updating lock file")
+            write_lock_file(env_name)
+
+        console.print(f"[bold green] :star: Done!")
+
+        if summary:
+            get_summary_for_revision(env_name)

--- a/ezconda/update.py
+++ b/ezconda/update.py
@@ -71,7 +71,7 @@ def update(
             console.print(f"[yellow]{str(p.stdout)}")
 
         console.print(
-            f"[bold green] :white_heavy_check_mark: '{env_name}' upadated!"
+            f"[bold green] :white_heavy_check_mark: '{env_name}' updated!"
         )
 
         if lock:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,8 @@ nav:
       - Remove packages : "user_guide/remove_packages.md"
     - Syncing Environment:
       - Sync local environment : "user_guide/sync_env.md"
+    - Update Packages & Environment:
+      - Update complete environment : "user_guide/update_environment.md"
     - Lock Environment:
       - Lock file for any environment : "user_guide/lock_existing_env.md"
     - Solvers:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -30,7 +30,6 @@ def check_if_pkg_is_installed(env_name, pkg_name, channel=None):
     if channel:
         for pkg in pkg_specs:
             if pkg["name"] == pkg_name:
-                print(pkg["channel"])
                 assert pkg["channel"] == channel
 
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,23 @@
+import pytest
+from typer.testing import CliRunner
+from ezconda.main import app
+from ezconda._utils import read_env_file, write_env_file
+
+
+runner = CliRunner()
+
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_env_sync_w_lockfile():
+    # create a new environment with packages
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.8", "numpy<1.20"])
+
+    # remove "<" dependencies from numpy
+    env_specs = read_env_file("test.yml")
+    env_specs["dependencies"][-1] = "numpy"
+    write_env_file(env_specs, "test.yml")
+
+    # update the environment test2 with new test2 lockfile
+    result = runner.invoke(app, ["update", "-n", "test"])
+
+    assert result.exit_code == 0

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -8,7 +8,7 @@ runner = CliRunner()
 
 
 @pytest.mark.usefixtures("clean_up_env_after_test")
-def test_env_sync_w_lockfile():
+def test_env_update():
     # create a new environment with packages
     _ = runner.invoke(app, ["create", "-n", "test", "python=3.8", "numpy<1.20"])
 
@@ -19,5 +19,37 @@ def test_env_sync_w_lockfile():
 
     # update the environment test2 with new test2 lockfile
     result = runner.invoke(app, ["update", "-n", "test"])
+
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_env_update_w_verbose():
+    # create a new environment with packages
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.8", "numpy<1.20"])
+
+    # remove "<" dependencies from numpy
+    env_specs = read_env_file("test.yml")
+    env_specs["dependencies"][-1] = "numpy"
+    write_env_file(env_specs, "test.yml")
+
+    # update the environment test2 with new test2 lockfile
+    result = runner.invoke(app, ["update", "-n", "test", "-v"])
+
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("clean_up_env_after_test")
+def test_env_update_w_conda():
+    # create a new environment with packages
+    _ = runner.invoke(app, ["create", "-n", "test", "python=3.8", "numpy<1.20"])
+
+    # remove "<" dependencies from numpy
+    env_specs = read_env_file("test.yml")
+    env_specs["dependencies"][-1] = "numpy"
+    write_env_file(env_specs, "test.yml")
+
+    # update the environment test2 with new test2 lockfile
+    result = runner.invoke(app, ["update", "-n", "test", "--solver", "conda"])
 
     assert result.exit_code == 0


### PR DESCRIPTION
This PR adds a new `update` command to update entire environments taking the specifications file into consideration.

The PR also updates relevant documentation for the `update` command.

Example usage:
```
ezconda update -n <env-name>
```

```
ezconda update -n <env-name> --file <specfile>
```

Closes #6 